### PR TITLE
Logic to handle crash reports on 10.8 systems upgraded from previous versions

### DIFF
--- a/Sources/Main/FRCrashLogFinder.m
+++ b/Sources/Main/FRCrashLogFinder.m
@@ -59,35 +59,36 @@
         NSDirectoryEnumerator *enumerator = nil;
         NSString *file = nil;
         
-        NSString* logDir2 = @"Logs/CrashReporter/";
-        logDir2 = [[libraryDirectory stringByAppendingPathComponent:logDir2] stringByExpandingTildeInPath];
+        NSString* logDir = @"Logs/CrashReporter/";
+        logDir = [[libraryDirectory stringByAppendingPathComponent:logDir] stringByExpandingTildeInPath];
 
         // NSLog(@"Searching for crash files at %@", logDir2);
 
         // 10.8 Mountain Lion no longer appears to create the Logs/CrashReporter directory
-        if (![fileManager fileExistsAtPath:logDir2]) {
+        NSString *logDir2 = @"Logs/DiagnosticReports/";
+        logDir2 = [[libraryDirectory stringByAppendingPathComponent:logDir2] stringByExpandingTildeInPath];
+        
+        NSArray *crashDirs = [NSArray arrayWithObjects:logDir, logDir2, nil];
 
-            logDir2 = @"Logs/DiagnosticReports/";
-            logDir2 = [[libraryDirectory stringByAppendingPathComponent:logDir2] stringByExpandingTildeInPath];
-        }
+        for (NSString *crashDir in crashDirs) {
+            if ([fileManager fileExistsAtPath:crashDir]) {
 
-        if ([fileManager fileExistsAtPath:logDir2]) {
+                enumerator  = [fileManager enumeratorAtPath:crashDir];
+                while ((file = [enumerator nextObject])) {
 
-            enumerator  = [fileManager enumeratorAtPath:logDir2];
-            while ((file = [enumerator nextObject])) {
+                    // NSLog(@"Checking crash file %@", file);
+                    
+                    NSString* expectedPrefix = [[FRApplication applicationName] stringByAppendingString:@"_"];
+                    if ([[file pathExtension] isEqualToString:@"crash"] && [[file stringByDeletingPathExtension] hasPrefix:expectedPrefix]) {
 
-                // NSLog(@"Checking crash file %@", file);
-                
-                NSString* expectedPrefix = [[FRApplication applicationName] stringByAppendingString:@"_"];
-                if ([[file pathExtension] isEqualToString:@"crash"] && [[file stringByDeletingPathExtension] hasPrefix:expectedPrefix]) {
+                        file = [[crashDir stringByAppendingPathComponent:file] stringByExpandingTildeInPath];
 
-                    file = [[logDir2 stringByAppendingPathComponent:file] stringByExpandingTildeInPath];
+                        if ([self file:file isNewerThan:date]) {
 
-                    if ([self file:file isNewerThan:date]) {
+                            // NSLog(@"Found crash file %@", file);
 
-                        // NSLog(@"Found crash file %@", file);
-
-                        [files addObject:file];
+                            [files addObject:file];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
First, FeedbackReporter is great. So great that when we decided to create a company support framework, I knew it would be the perfect base. We're planning to make a bunch of changes to suit our needs and I doubt most of them would fit within your upstream FeedbackReporter, but I will do my best to submit pull requests for bug fixes or things that might be more appropriate.

This is the first of those. I discovered that FeedbackReporter didn't detect crashes on my system. I found after debugging it that the problem was it would see the pre 10.8 crash log folder and assume the system was pre-10.8, even though the 10.8 folder existed as well. This changes the logic to look in both places.
