### PR TITLE
Workaround for issue #25

### DIFF
--- a/Sources/Main/FRExceptionReportingApplication.m
+++ b/Sources/Main/FRExceptionReportingApplication.m
@@ -28,7 +28,19 @@
     @try {
         if (!pthread_main_np()) {
             [[FRFeedbackReporter sharedReporter] performSelectorOnMainThread:@selector(reportException:) withObject:x waitUntilDone:NO];
-            [NSThread exit];
+
+            // We can't exit dispatch queue, so we make it sleep forever.
+            BOOL isSimpleThread = ([[[NSThread callStackSymbols] lastObject]
+                                    rangeOfString:@"thread_start"].location != NSNotFound);
+            
+            if (isSimpleThread)
+            {
+                [NSThread exit];
+            }
+            else
+            {
+                [NSThread sleepUntilDate:[NSDate distantFuture]];
+            }
         }
         else {
             [[FRFeedbackReporter sharedReporter] reportException:x];


### PR DESCRIPTION
Hi,

here is workaround of issue #25 - inability to call [NSThread exit] on dispatch queue. I'm not sure if it's a proper fix (making dispatch queue sleep forever) but it works fine for our projects.

Thanks,
Vera.
